### PR TITLE
Kargo/promotion/last.01k44vck7cp0ggbwnssnhrnhjg.a7b3afb

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 - deployment.yaml
 images:
 - name: nginx
-  newTag: 1.25.1
+  newTag: 1.25.2

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -2,5 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - common/namespace.yaml # <-- Submodule 안의 파일을 직접 참조하는 핵심 부분!
-  - deployment.yaml
+- common/namespace.yaml # <-- Submodule 안의 파일을 직접 참조하는 핵심 부분!
+- deployment.yaml
+images:
+- name: nginx
+  newTag: 1.25.1


### PR DESCRIPTION
ㅁㅇㅁㄴㅁ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Pinned the web server container image to nginx 1.25.2 so deployments consistently use this version across environments.
  * Locked image tag improves reproducibility and predictability of rollouts.
* Style
  * Reformatted configuration entries for readability; resource references are unchanged and behavior remains the same for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->